### PR TITLE
Add custom resource name to BOSH connection

### DIFF
--- a/README
+++ b/README
@@ -19,6 +19,12 @@ In your Ruby app controller (or equivalent):
 @session_jid, @session_id, @session_random_id = 
   RubyBOSH.initialize_session("me@jabber.org", "my_password", "http://localhost:5280/http-bind")
 
+If you want to define your own resource name, include it within the jid.  RubyBOSH will create a random one if none is supplied.
+To define a resource name of 'home', do the following:
+
+@session_jid, @session_id, @session_random_id = 
+  RubyBOSH.initialize_session("me@jabber.org/home", "my_password", "http://localhost:5280/http-bind")
+
 In your template, you would then pass these directly to your javascript BOSH connector:
 
 var bosh_jid = '<%= @session_jid %>';

--- a/lib/ruby_bosh.rb
+++ b/lib/ruby_bosh.rb
@@ -22,10 +22,14 @@ class RubyBOSH
     @@logging = value
   end
 
-  attr_accessor :jid, :rid, :sid, :success
+  attr_accessor :jid, :rid, :sid, :success , :custom_resource
   def initialize(jid, pw, service_url, opts={}) 
     @service_url = service_url
-    @jid, @pw = jid, pw
+    # Extract the resource if present
+    split_jid = jid.split("/")
+    @jid = split_jid.first
+    @custom_resource = @jid.last if split_jid.length > 1
+    @pw = pw
     @host = jid.split("@").last
     @success = false
     @timeout = opts[:timeout] || 3 #seconds 
@@ -102,7 +106,7 @@ class RubyBOSH
       body.iq(:id => "bind_#{rand(100000)}", :type => "set", 
               :xmlns => "jabber:client") do |iq|
         iq.bind(:xmlns => BIND_XMLNS) do |bind|
-          bind.resource("bosh_#{rand(10000)}")
+          bind.resource(resource_name)
         end
       end
     end
@@ -175,6 +179,15 @@ class RubyBOSH
   def now 
     Time.now.strftime("%a %b %d %H:%M:%S %Y")
   end
+
+  def resource_name
+    if @custom_resource.nil?
+      "bosh_#{rand(10000)}"
+    else
+      @custom_resource
+    end
+  end
+
 end
 
 

--- a/lib/ruby_bosh.rb
+++ b/lib/ruby_bosh.rb
@@ -28,9 +28,9 @@ class RubyBOSH
     # Extract the resource if present
     split_jid = jid.split("/")
     @jid = split_jid.first
-    @custom_resource = @jid.last if split_jid.length > 1
+    @custom_resource = split_jid.last if split_jid.length > 1
     @pw = pw
-    @host = jid.split("@").last
+    @host = @jid.split("@").last
     @success = false
     @timeout = opts[:timeout] || 3 #seconds 
     @headers = {"Content-Type" => "text/xml; charset=utf-8",
@@ -187,7 +187,6 @@ class RubyBOSH
       @custom_resource
     end
   end
-
 end
 
 


### PR DESCRIPTION
Hi.

Thanks for a great little library.  It has really helped me out in setting up Rails and XMPP.

I needed the ability to set the resource name when initialising the BOSH connection.  I have added the simple code to make that happen.  You just need to add the name at the end if the jid like so: 

me@jabber.org/home 

This is the same way Strophe works when creating a connection.  I also updated the Readme to include the above example.

Thanks again.

Kind Regards
Hamza Khan-Cheema
